### PR TITLE
PropertiesEnhancer doesn't work when multiple setter exists

### DIFF
--- a/enhancer/src/main/java/play/core/enhancers/PropertiesEnhancer.java
+++ b/enhancer/src/main/java/play/core/enhancers/PropertiesEnhancer.java
@@ -97,7 +97,7 @@ public class PropertiesEnhancer {
                     }
 
                     try {
-                        CtMethod ctMethod = ctClass.getDeclaredMethod(setter);
+                        CtMethod ctMethod = ctClass.getDeclaredMethod(setter, new CtClass [] { ctField.getType() });
                         if (ctMethod.getParameterTypes().length != 1 || !ctMethod.getParameterTypes()[0].equals(ctField.getType()) || Modifier.isStatic(ctMethod.getModifiers())) {
                             throw new NotFoundException("it's not a setter !");
                         }

--- a/plugin/src/sbt-test/play-enhancer/enhanced/src/main/java/play/test/enhancer/ComplexBean.java
+++ b/plugin/src/sbt-test/play-enhancer/enhanced/src/main/java/play/test/enhancer/ComplexBean.java
@@ -1,0 +1,31 @@
+package play.test.enhancer;
+
+public class ComplexBean {
+    public String existingGetter;
+
+    public String getExistingGetter() {
+        return existingGetter;
+    }
+
+    public String existingSetter;
+
+    public void setExistingSetter(String value) {
+        this.existingSetter = value;
+    }
+
+    public String differentTypeSetter;
+
+    public void setDifferentTypeSetter(int value) {
+        this.differentTypeSetter = Integer.toString(value);
+    }
+
+    public String multipleSetters;
+
+    public void setMultipleSetters(int value) {
+        this.multipleSetters = Integer.toString(value);
+    }
+
+    public void setMultipleSetters(String value) {
+        this.multipleSetters = value;
+    }
+}


### PR DESCRIPTION
From https://github.com/playframework/playframework/issues/824

A simple Java class in a Play project fails to compile (DuplicateMemberException) due to the way sbt-link's PropertiesEnhancer is implemented:

class Test {
  public int ByteBuffer value;
  // ...
  public byte [] getValue() { return value.array(); }
  public Test setValue(byte [] value) { return setValue(ByteBuffer.wrap(value)); }
  public Test setValue(ByteBuffer buffer) { this.value = value; return this; }
}
This kind of Java code gets automatically generated by Apache Thrift for instance. It's not an option to rewrite the class in question and it's a valid Java code anyway.

After investigating the method PropertiesEnhancer.generateAccessors() I found a way to solve the issue by explicitly asking for a setter with one parameter of the same type as the property being "enhanced":

line 97: CtMethod ctMethod = ctClass.getDeclaredMethod(setter, new CtClass [] { ctField.getType() });

instead of (currently):

line 97: CtMethod ctMethod = ctClass.getDeclaredMethod(setter);

It's quite wrong to assume that only one "setXyz" method exist in a given class. It solves the compilation error and I haven't noticed any drawbacks so far. Though I am not 100% sure what is the purpose of the property enhancer in the Play framework so I can't guarantee that this fix won't break other use cases.

Cheers.
