### PR TITLE
Build with OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-jdk: openjdk6
+jdk: openjdk8
 language: scala
 script: sbt +publishLocal +test +scripted
 sudo: false


### PR DESCRIPTION
OpenJDK 6 is no longer available on Travis CI.